### PR TITLE
Allow for ow in env vars and make init async

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For the server side code see: [adobe/adobeio-cna-token-vending-machine](https://
 ```javascript
 const TvmClient = require('@adobe/adobeio-cna-tvm-client')
 // init
-const tvm = TvmClient.init({ ow: { auth: '<myauth>', namespace: '<mynamespace>' } })
+const tvm = await TvmClient.init({ ow: { auth: '<myauth>', namespace: '<mynamespace>' } })
 
 // aws s3
 const awsS3Credentials = await tvm.getAwsS3Credentials()

--- a/doc/api.md
+++ b/doc/api.md
@@ -20,7 +20,7 @@
 blob container. These two signed URLs can then be passed to the azure blob storage sdk, see the example below:</p>
 </dd>
 <dt><a href="#TvmResponseAzureCosmos">TvmResponseAzureCosmos</a> : <code>object</code></dt>
-<dd><p>Tvm response with Azure Cosmos resource credentials. Gives access to a personal Cosmos container.</p>
+<dd><p>Tvm response with Azure Cosmos resource credentials. Gives access to an isolated partition within a CosmosDB container.</p>
 </dd>
 <dt><a href="#TvmResponseAwsS3">TvmResponseAwsS3</a> : <code>object</code></dt>
 <dd><p>Tvm response with Aws S3 temporary credentials. These credentials give access to files in a restricted prefix:
@@ -42,7 +42,7 @@ Client SDK for Token Vending Machine (TVM)
         * [.getAwsS3Credentials()](#TvmClient+getAwsS3Credentials) ⇒ [<code>Promise.&lt;TvmResponseAwsS3&gt;</code>](#TvmResponseAwsS3)
         * [.getAzureCosmosCredentials()](#TvmClient+getAzureCosmosCredentials) ⇒ [<code>Promise.&lt;TvmResponseAzureCosmos&gt;</code>](#TvmResponseAzureCosmos)
     * _static_
-        * [.init(config)](#TvmClient.init) ⇒ [<code>TvmClient</code>](#TvmClient)
+        * [.init(config)](#TvmClient.init) ⇒ [<code>Promise.&lt;TvmClient&gt;</code>](#TvmClient)
 
 <a name="TvmClient+getAzureBlobCredentials"></a>
 
@@ -105,16 +105,16 @@ const data = await container.item('<itemKey>', azureCosmosCredentials.partitionK
 
 <a name="TvmClient.init"></a>
 
-### TvmClient.init(config) ⇒ [<code>TvmClient</code>](#TvmClient)
+### TvmClient.init(config) ⇒ [<code>Promise.&lt;TvmClient&gt;</code>](#TvmClient)
 Creates a TvmClient instance
 
 ```javascript
 const TvmClient = require('@adobe/adobeio-cna-tvm-client')
-const tvm = TvmClient.init({ ow: { namespace, auth } })
+const tvm = await TvmClient.init({ ow: { namespace, auth } })
 ```
 
 **Kind**: static method of [<code>TvmClient</code>](#TvmClient)  
-**Returns**: [<code>TvmClient</code>](#TvmClient) - new instance  
+**Returns**: [<code>Promise.&lt;TvmClient&gt;</code>](#TvmClient) - new instance  
 **Throws**:
 
 - [<code>TvmError</code>](#TvmError) 
@@ -124,7 +124,7 @@ const tvm = TvmClient.init({ ow: { namespace, auth } })
 | --- | --- | --- |
 | config | <code>object</code> | TvmClientParams |
 | config.apiUrl | <code>string</code> | url to tvm api |
-| config.ow | [<code>OpenWhiskCredentials</code>](#OpenWhiskCredentials) | Openwhisk credentials |
+| [config.ow] | [<code>OpenWhiskCredentials</code>](#OpenWhiskCredentials) | Openwhisk credentials. As an alternative you can pass those through environment variables: `__OW_NAMESPACE` and `__OW_AUTH` |
 | [config.cacheFile] | <code>string</code> | if omitted defaults to tmpdir/.tvmCache, use false or null to not cache |
 
 <a name="TvmError"></a>
@@ -200,7 +200,7 @@ blob container. These two signed URLs can then be passed to the azure blob stora
 <a name="TvmResponseAzureCosmos"></a>
 
 ## TvmResponseAzureCosmos : <code>object</code>
-Tvm response with Azure Cosmos resource credentials. Gives access to a personal Cosmos container.
+Tvm response with Azure Cosmos resource credentials. Gives access to an isolated partition within a CosmosDB container.
 
 **Kind**: global typedef  
 **Properties**
@@ -209,9 +209,9 @@ Tvm response with Azure Cosmos resource credentials. Gives access to a personal 
 | --- | --- | --- |
 | endpoint | <code>string</code> | cosmosdb resource endpoint |
 | resourceToken | <code>string</code> | cosmosdb resource token restricted to access the items in the partitionKey |
-| partitionKey | <code>string</code> | key to accessible cosmosdb partition |
-| containerId | <code>string</code> | id to cosmosdb container where partition lives |
-| databaseId | <code>string</code> | id to cosmosdb database where container lives |
+| databaseId | <code>string</code> | id for cosmosdb database |
+| containerId | <code>string</code> | id for cosmosdb container within database |
+| partitionKey | <code>string</code> | key for cosmosdb partition within container authorized by resource token |
 | expiration | <code>string</code> | expiration date ISO/UTC |
 
 <a name="TvmResponseAwsS3"></a>

--- a/lib/TvmClient.js
+++ b/lib/TvmClient.js
@@ -117,19 +117,30 @@ class TvmClient {
    *
    * ```javascript
    * const TvmClient = require('@adobe/adobeio-cna-tvm-client')
-   * const tvm = TvmClient.init({ ow: { namespace, auth } })
+   * const tvm = await TvmClient.init({ ow: { namespace, auth } })
    * ```
    *
    * @param  {object} config TvmClientParams
    * @param  {string} config.apiUrl url to tvm api
-   * @param  {OpenWhiskCredentials} config.ow Openwhisk credentials
+   * @param  {OpenWhiskCredentials} [config.ow] Openwhisk credentials. As an alternative you can pass those through environment
+   * variables: `__OW_NAMESPACE` and `__OW_AUTH`
    * @param  {string} [config.cacheFile] if omitted defaults to
    * tmpdir/.tvmCache, use false or null to not cache
-   * @returns {TvmClient} new instance
+   * @returns {Promise<TvmClient>} new instance
    * @memberof TvmClient
    * @throws {TvmError}
    */
-  static init (config) {
+  static async init (config = {}) { // no need for async now, but let's keep it consistent with rest of sdk
+    // include ow environment vars to credentials
+    const namespace = process.env['__OW_NAMESPACE']
+    const auth = process.env['__OW_AUTH']
+    if (namespace || auth) {
+      if (typeof config.ow !== 'object') {
+        config.ow = {}
+      }
+      config.ow.namespace = config.ow.namespace || namespace
+      config.ow.auth = config.ow.auth || auth
+    }
     return new TvmClient(config)
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Make init async : as it is the case for all other sdks + might need async operations in the future
- Allow for ow credentials to be passed through __OW_AUTH and __OW_NAMESPACE

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
